### PR TITLE
doc: bazel usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,34 @@ object Main extends App {
 }
 ```
 
+## Build
 
+### Bazel
 
+The `Result` type can be easily added to an existing Bazel rules_scala based
+project by adding the following to the project's `WORKSPACE`.
 
+```starlark
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
+# Target: "@result.scala//:result-lib"
+new_git_repository(
+    name = "result.scala",
+    build_file_content = """
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+scala_library(
+    name = "result-lib",
+    srcs = ["Result.scala"],
+    visibility = ["//visibility:public"],
+)
+    """,
+    # Replace with desired commit hash to upgrade
+    # shallow_since will also need to be replaced
+    commit = "45e994e18aef658888a5adb274e0a087ee8da556",
+    remote = "https://github.com/ycd/result.scala.git",
+    # bazel build debug messages will recommend a replacement value if cleared
+    shallow_since = "1652112382 +0300",
+    strip_prefix = "src/main/scala",
+)
+```
 


### PR DESCRIPTION
Adding some quick documentation on how `Result.scala` can be used by a Bazel project.

The documented pattern can/should change in the future if jars are published to Maven, GitHub, etc... but that is certainly a more involved and complicated process as individual jars would be needed to support multiple versions of Scala.