### PR TITLE
Introduce `flatMap` method

### DIFF
--- a/src/main/scala/Result.scala
+++ b/src/main/scala/Result.scala
@@ -93,6 +93,6 @@ case class Ok[T, E](v: T) extends AnyVal with Result[T, E] {
 }
 
 case class Err[T, E](e: E) extends AnyVal with Result[T, E] {
-  override def map[U](f: T => U): Result[U, E] = this.asInstanceOf[Result[U, E]]
-  override def flatMap[U, F >: E](f: T => Result[U, F]): Result[U, F] = this.asInstanceOf[Result[U, F]]
+  override def map[U](f: T => U): Result[U, E] = Err(e)
+  override def flatMap[U, F >: E](f: T => Result[U, F]): Result[U, F] = Err(e)
 }

--- a/src/main/scala/Result.scala
+++ b/src/main/scala/Result.scala
@@ -94,5 +94,5 @@ case class Ok[T, E](v: T) extends AnyVal with Result[T, E] {
 
 case class Err[T, E](e: E) extends AnyVal with Result[T, E] {
   override def map[U](f: T => U): Result[U, E] = this.asInstanceOf[Result[U, E]]
-  override def def flatMap[U, F >: E](f: T => Result[U, F]): Result[U, F] = this.asInstanceOf[Result[U, F]]
+  override def flatMap[U, F >: E](f: T => Result[U, F]): Result[U, F] = this.asInstanceOf[Result[U, F]]
 }

--- a/src/main/scala/Result.scala
+++ b/src/main/scala/Result.scala
@@ -84,12 +84,15 @@ sealed trait Result[+T, +E] extends Any {
   // Maps a `Result[T, E]` to `Result[U, E]` by applying a function to a
   // contained [`Ok`] value, leaving an [`Err`] value untouched.
   def map[U](f: T => U): Result[U, E]
+  def flatMap[U, F >: E](f: T => Result[U, F]): Result[U, F]
 }
 
 case class Ok[T, E](v: T) extends AnyVal with Result[T, E] {
   override def map[U](f: T => U): Result[U, E] = Ok(f(v))
+  override def flatMap[U, F >: E](f: T => Result[U, F]): Result[U, F] = f(v)
 }
 
 case class Err[T, E](e: E) extends AnyVal with Result[T, E] {
   override def map[U](f: T => U): Result[U, E] = this.asInstanceOf[Result[U, E]]
+  override def def flatMap[U, F >: E](f: T => Result[U, F]): Result[U, F] = this.asInstanceOf[Result[U, F]]
 }


### PR DESCRIPTION
Hi there! Thank you for providing this library 😄

I'm writing a lot of code like this:

```scala
result match {
  case Ok(x) =>
   // code that might return Ok() or Err()
  case Err(e) => Err(e)
}
```

Introducing this allows you to simplify this code to:

```scala
result.flatMap { x =>
  // code that might return Ok() or Err()
}
```

The advantage over `map` being that it allows you to chain several operations that may individually fail, whereas doing that with map would result in `Result[Result[T, Err], Err]`.

I also made a subtle change to the `map` implementation for `Err` which I think is equivalent and seems slightly nicer to me, but I'm a bit of a novice so I may be missing a reason for preferring `asInstanceOf` here